### PR TITLE
feat(auth): Enhance password recovery and reset UI/UX

### DIFF
--- a/android/app/src/main/kotlin/com/spareboy/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/spareboy/app/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.spareboy.app
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity: FlutterActivity()

--- a/lib/core/constants/app_colors.dart
+++ b/lib/core/constants/app_colors.dart
@@ -7,6 +7,8 @@ class AppColors {
 
   static const Color background = Color(0xFFF8F8F8);
 
+  static const Color blackPrimary = Color(0xff202020);
+
   static const Color textPrimary = Color(0xff202020);
   static const Color textSecondary =  Color(0xFFF3F3F3);
   static const Color textFormField = Color(0xFFD2D2D2);

--- a/lib/features/authentication/views/login.dart
+++ b/lib/features/authentication/views/login.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:spare_boy/core/constants/app_colors.dart';
-import 'package:spare_boy/features/authentication/views/recoveryMode.dart';
+import 'package:spare_boy/features/authentication/views/recovery_mode.dart';
 import 'package:spare_boy/features/authentication/views/signUp.dart';
 import 'package:spare_boy/features/common/widgets/buttons.dart';
 import 'package:spare_boy/features/common/widgets/textfields.dart';
@@ -54,7 +54,7 @@ class _LoginScreenState extends State<LoginScreen> {
                     const SizedBox(width: 5),
                     const Icon(
                       Icons.favorite,
-                      color: AppColors.textPrimary,
+                      color: AppColors.blackPrimary,
                       size: 20,
                     ),
                   ],
@@ -76,7 +76,7 @@ class _LoginScreenState extends State<LoginScreen> {
                         icon: Icon(
                           showPassword ? Icons.visibility : Icons.visibility_off,
                         ),
-                        color: AppColors.textPrimary,
+                        color: AppColors.blackPrimary,
                         onPressed: () {
                           setState(() {
                             showPassword = !showPassword;

--- a/lib/features/authentication/views/password_reset.dart
+++ b/lib/features/authentication/views/password_reset.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:spare_boy/core/constants/app_colors.dart';
+import 'package:spare_boy/features/authentication/views/login.dart';
+import 'package:spare_boy/features/common/widgets/buttons.dart';
+import 'package:spare_boy/features/common/widgets/circle_avatar.dart';
+import 'package:spare_boy/features/common/widgets/textfields.dart';
+
+class PasswordReset extends StatefulWidget {
+  const PasswordReset({super.key});
+
+  @override
+  State<PasswordReset> createState() => _PasswordResetState();
+}
+
+class _PasswordResetState extends State<PasswordReset> {
+  bool showPassword = false;
+  bool showConfirmPassword = false;
+  final _formKey = GlobalKey<FormState>();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SingleChildScrollView(
+        physics: const BouncingScrollPhysics(),
+        child: Container(
+          height: MediaQuery.of(context).size.height,
+          margin: const EdgeInsets.symmetric(horizontal: 20),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.end,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const AvatarCicle(
+                shadowSpreadRadius: -2,
+                size: 40,
+                child: Icon(
+                  Icons.key_rounded,
+                  size: 40,
+                  color: AppColors.textPrimary,
+                ),
+              ),
+              const SizedBox(height: 20),
+              Text(
+                'Setup New Password',
+                style: GoogleFonts.raleway(
+                  fontSize: 21,
+                  fontWeight: FontWeight.bold,
+                  color: AppColors.textPrimary,
+                  letterSpacing: -0.21,
+                ),
+              ),
+              const SizedBox(height: 5),
+              Text(
+                'Please, setup a new password for your account',
+                textAlign: TextAlign.center,
+                style: GoogleFonts.nunitoSans(
+                  fontSize: 19,
+                  fontWeight: FontWeight.w300,
+                  color: AppColors.textPrimary,
+                ),
+                maxLines: 3,
+              ),
+              const SizedBox(height: 25),
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    OnboardingTextField(
+                      label: 'New Password',
+                      controller: _passwordController,
+                      showPassword: showPassword,
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          showPassword
+                              ? Icons.visibility
+                              : Icons.visibility_off,
+                        ),
+                        color: AppColors.blackPrimary,
+                        onPressed: () {
+                          setState(() {
+                            showPassword = !showPassword;
+                          });
+                        },
+                      ),
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Please enter a password';
+                        }
+                        if (value.length < 6) {
+                          return 'Password must be at least 6 characters';
+                        }
+                        return null;
+                      },
+                    ),
+                    OnboardingTextField(
+                      label: 'Confirm Password',
+                      controller: _confirmPasswordController,
+                      showPassword: showConfirmPassword,
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          showConfirmPassword
+                              ? Icons.visibility
+                              : Icons.visibility_off,
+                        ),
+                        color: AppColors.blackPrimary,
+                        onPressed: () {
+                          setState(() {
+                            showConfirmPassword = !showConfirmPassword;
+                          });
+                        },
+                      ),
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Please confirm your password';
+                        }
+                        if (value != _passwordController.text) {
+                          return 'Passwords do not match';
+                        }
+                        return null;
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 170),
+              OnboardingButton(
+                text: 'Reset Password',
+                onPressed: () {
+                  if (_formKey.currentState!.validate()) {
+                    // Password reset logic here
+                    Navigator.pushAndRemoveUntil(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const LoginScreen(),
+                      ),
+                      (route) => false,
+                    );
+                  }
+                },
+                minimumSize: const Size(325, 60),
+              ),
+              const SizedBox(height: 15),
+              CancelButton(
+                onTap: () {
+                  Navigator.pop(context);
+                },
+              ),
+              const SizedBox(height: 15),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/authentication/views/recovery_mode.dart
+++ b/lib/features/authentication/views/recovery_mode.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:spare_boy/core/constants/app_colors.dart';
-import 'package:spare_boy/features/authentication/views/recoveryPage.dart';
+import 'package:spare_boy/features/authentication/views/recovery_page.dart';
 import 'package:spare_boy/features/common/widgets/buttons.dart';
 import 'package:spare_boy/features/common/widgets/circle_avatar.dart';
 
@@ -34,7 +34,7 @@ class _RecoveryModeState extends State<RecoveryMode> {
                 child: Icon(
                   Icons.priority_high_rounded,
                   size: 40,
-                  color: AppColors.textPrimary,
+                  color: AppColors.blackPrimary,
                 ),
               ),
             ),
@@ -89,12 +89,12 @@ class _RecoveryModeState extends State<RecoveryMode> {
         height: 45,
         decoration: BoxDecoration(
           color: _selectedOption == option
-              ? AppColors.textPrimary.withOpacity(0.1)
+              ? AppColors.blackPrimary.withOpacity(0.1)
               : Colors.grey[200],
           borderRadius: BorderRadius.circular(50),
         ),
         child: InkWell(
-          hoverColor: AppColors.textPrimary.withOpacity(0.1),
+          hoverColor: AppColors.blackPrimary.withOpacity(0.1),
           borderRadius: BorderRadius.circular(50),
           onTap: () {
             setState(() {
@@ -134,7 +134,7 @@ class _RecoveryModeState extends State<RecoveryMode> {
                           height: 30,
                           decoration: const BoxDecoration(
                             shape: BoxShape.circle,
-                            color: AppColors.textPrimary,
+                            color: AppColors.blackPrimary,
                           ),
                           child: const Icon(
                             Icons.check,

--- a/lib/features/authentication/views/recovery_page.dart
+++ b/lib/features/authentication/views/recovery_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:pinput/pinput.dart';
 import 'package:spare_boy/core/constants/app_colors.dart';
+import 'package:spare_boy/features/authentication/views/password_reset.dart';
 import 'package:spare_boy/features/common/widgets/buttons.dart';
 import 'package:spare_boy/features/common/widgets/circle_avatar.dart';
 
@@ -13,26 +14,68 @@ class RecoveryPage extends StatefulWidget {
 }
 
 class _RecoveryPageState extends State<RecoveryPage> {
+  TextEditingController otpController = TextEditingController();
 
+  final PinTheme defaultPinTheme = PinTheme(
+    textStyle: GoogleFonts.nunitoSans(
+      fontSize: 19,
+      fontWeight: FontWeight.w600,
+      color: AppColors.textPrimary,
+    ),
+    width: 55,
+    height: 55,
+    decoration: BoxDecoration(
+      color: Colors.grey[200],
+      borderRadius: BorderRadius.circular(12),
+    ),
+  );
 
+  final PinTheme focusedPinTheme = PinTheme(
+    textStyle: GoogleFonts.nunitoSans(
+      fontSize: 19,
+      fontWeight: FontWeight.w600,
+      color: AppColors.textPrimary,
+    ),
+    width: 55,
+    height: 55,
+    decoration: BoxDecoration(
+      color: const Color.fromARGB(255, 210, 210, 210),
+      borderRadius: BorderRadius.circular(12),
+    ),
+  );
+
+  final PinTheme errorPinTheme = PinTheme(
+    textStyle: GoogleFonts.nunitoSans(
+      fontSize: 19,
+      fontWeight: FontWeight.w600,
+      color: Colors.red,
+    ),
+    width: 55,
+    height:55,
+    decoration: BoxDecoration(
+      color: Colors.grey[200],
+      borderRadius: BorderRadius.circular(12),
+      border: Border.all(color: Colors.red),
+    ),
+  );
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: SingleChildScrollView(
-        child: Container(
+        child: SizedBox(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.end,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               const SizedBox(height: 40),
-              AvatarCicle(
+              const AvatarCicle(
+                shadowSpreadRadius: -2,
                 size: 40,
-                color: Colors.grey[200],
                 child: Icon(
-                  Icons.priority_high_rounded,
+                  Icons.security_rounded, 
                   size: 40,
                   color: AppColors.textPrimary,
                 ),
@@ -67,54 +110,38 @@ class _RecoveryPageState extends State<RecoveryPage> {
               ),
               const SizedBox(height: 30),
               Pinput(
+                controller: otpController,
+                defaultPinTheme: defaultPinTheme,
+                focusedPinTheme: focusedPinTheme,
+                errorPinTheme: errorPinTheme,
+                keyboardType: TextInputType.number,
                 length: 4,
                 showCursor: false,
-                defaultPinTheme: PinTheme(
-                  textStyle: GoogleFonts.nunitoSans(
-                    fontSize: 19,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.textPrimary,
-                  ),
-                  width: 55,
-                  height: 55,
-                  decoration: BoxDecoration(
-                    color: Colors.grey[200],
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                ),
-                focusedPinTheme:PinTheme(
-                  textStyle: GoogleFonts.nunitoSans(
-                    fontSize: 19,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.textPrimary,
-                  ),
-                  width: 55,
-                  height: 55,
-                  decoration: BoxDecoration(
-                    color: const Color.fromARGB(255, 210, 210, 210),
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                ),
-                errorPinTheme: PinTheme(
-                  textStyle: GoogleFonts.nunitoSans(
-                    fontSize: 19,
-                    fontWeight: FontWeight.w600,
-                    color: Colors.red,
-                  ),
-                  width: 55,
-                  height: 55,
-                  decoration: BoxDecoration(
-                    color: Colors.red[100],
-                    borderRadius: BorderRadius.circular(12),
-                    border: Border.all(color: Colors.red),
-                  ),
-                ),
+                onCompleted: (value) async {
+                  otpController.clear();
+                  if (value == '1234') {
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const PasswordReset(),
+                      ),
+                    );
+                  }
+                },
+                validator: (value) {
+                  if (value != '1234' || value!.length != 4) {
+                    return 'Please enter a valid 4-digit code';
+                  }
+                  return null;
+                },
               ),
-              const Spacer(),
+              const SizedBox(height: 150,),
               OnboardingButton(
                 minimumSize: const Size(220, 60),
                 text: 'Send Again',
-                onPressed: () {},
+                onPressed: () {
+                  otpController.clear();
+                },
               ),
               const SizedBox(height: 17),
               CancelButton(

--- a/lib/features/common/widgets/textfields.dart
+++ b/lib/features/common/widgets/textfields.dart
@@ -9,6 +9,7 @@ class OnboardingTextField extends StatelessWidget {
   final FormFieldValidator validator;
   final TextInputType? keyBoardType;
   final bool? showPassword;
+  final TextEditingController? controller;
   const OnboardingTextField(
       {super.key, 
       required this.label,
@@ -16,6 +17,7 @@ class OnboardingTextField extends StatelessWidget {
       this.keyBoardType,
       this.suffixIcon,
       this.showPassword,
+      this.controller,
     });
 
   @override
@@ -50,6 +52,7 @@ class OnboardingTextField extends StatelessWidget {
         obscureText: showPassword ?? false,
         validator: validator,
         keyboardType: keyBoardType ?? TextInputType.text,
+        controller: controller,
       ),
     );
   }


### PR DESCRIPTION
- Add OTP controller and clear functionality in recovery page
- Replace navigation push with pushReplacement for smoother transitions
- Update icons to be more contextual (security for recovery, key for reset)
- Add shadow spread radius to avatar circles for better visual depth
- Improve password reset page layout and styling
- Add clear OTP functionality when clicking 'Send Again'
- Fix PIN validation and navigation flow
- Implement proper error states for PIN input

UI/UX Improvements:
- Center-aligned text and elements for better visual hierarchy
- Consistent spacing and padding throughout forms
- Better visual feedback for user interactions